### PR TITLE
A couple of minor fixes for Visual Studio 2013 Preview

### DIFF
--- a/lest.hpp
+++ b/lest.hpp
@@ -9,6 +9,7 @@
 #include <iostream>
 #include <functional>
 #include <stdexcept>
+#include <string>
 
 #ifndef lest_NO_SHORT_ASSERTION_NAMES
 # define EXPECT           lest_EXPECT
@@ -22,7 +23,7 @@
         if ( ! (expr) ) \
             throw lest::failure{ lest_LOCATION, #expr }; \
     } \
-    catch( lest::failure const & e ) \
+    catch( lest::failure const & ) \
     { \
         throw ; \
     } \


### PR DESCRIPTION
Hi Martin!

Thanks for a great library!

I've tried to use lest with Visual Studio 2013 Preview. It works fine.

Here is my 2 minor fixes:
- Added #include for correct std::string  using with std::ostream
- Removed unused name e to avoid C4101 warning
