### PR TITLE
Compatibility with GCC 4.6 for lest.hpp

### DIFF
--- a/lest.hpp
+++ b/lest.hpp
@@ -87,6 +87,8 @@ struct message : std::runtime_error
     const location where;
     const comment note;
 
+    ~message() throw() {}
+
     message( std::string kind, location where, std::string expr, std::string note = "" )
     : std::runtime_error{ expr }, kind{ kind }, where{ where }, note{ note } {}
 };


### PR DESCRIPTION
This copies one line from lest_cpp03.hpp  in order to support GCC 4.6.

GCC 4.6 is the compiler that ships with the current Ubuntu long term support release (12.04 LTS). It's probably the oldest version of GCC still worth caring about.
