### PR TITLE
fixed compilation errors in lest.hpp

### DIFF
--- a/lest.hpp
+++ b/lest.hpp
@@ -24,6 +24,7 @@
 #include <vector>
 
 #include <cctype>
+#include <cmath>
 #include <cstddef>
 
 #ifndef  lest_FEATURE_LITERAL_SUFFIX


### PR DESCRIPTION
I kept getting the following compilation error:

```
lest/lest.hpp:278:93: error: call to
      'abs' is ambiguous
  ...rhs.magnitude_ ) < rhs.epsilon_ * ( rhs.scale_ + (std::max)( std::abs( lhs ), std:...
```

This was fixed by adding `#include <cmath>`
