### PR TITLE
 Added reporting of intermediate description text from nested CASE, SETUP, and SECTIONs

### DIFF
--- a/example/CMakeLists.txt
+++ b/example/CMakeLists.txt
@@ -11,6 +11,8 @@ cmake_minimum_required( VERSION 2.8 )
 
 project( examples )
 
+include_directories("../include/lest")
+
 # single-file sources:
 
 set( SOURCES_CPP03

--- a/include/lest/lest.hpp
+++ b/include/lest/lest.hpp
@@ -101,12 +101,9 @@
 #define lest_TEST \
     lest_CASE
 
-
-
 #if lest_FEATURE_AUTO_REGISTER
 
 # define lest_CASE( specification, proposition ) \
-    lest::context_description lest_UNIQUE(info) { std::string(proposition)}; \
     static void lest_FUNCTION( lest::env & ); \
     namespace { lest::add_test lest_REGISTRAR( specification, lest::test( proposition, lest_FUNCTION ) ); } \
     static void lest_FUNCTION( lest::env & lest_env )
@@ -129,7 +126,7 @@
     static int lest_UNIQUE( id ) = 0; \
     if ( lest::guard( lest_UNIQUE( id ), lest__section, lest__count ) ) \
         for ( int lest__section = 0, lest__count = 1; lest__section < lest__count; lest__count -= 0==lest__section++ ) \
-        if (lest::context_description context_data = lest::context_description(proposition))
+            if (lest::context_description context_data = lest::context_description(proposition))
 
 #define lest_EXPECT( expr ) \
     do { \
@@ -447,16 +444,16 @@ inline void inform( location where, text expr )
 
 namespace detail {
 
-text error_context_g;
+static text error_context_g;
 
 } // namespace detail
 
-text get_error_context()
+inline text get_error_context()
 {
     return detail::error_context_g;
 }
 
-void prepend_error_context(text context)
+inline void prepend_error_context(text context)
 {
     if (detail::error_context_g == "")
     {
@@ -468,7 +465,7 @@ void prepend_error_context(text context)
     }
 }
 
-void reset_error_context()
+inline void reset_error_context()
 {
     detail::error_context_g = "";
 }

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -16,6 +16,8 @@ add_executable( test_lest_cpp03     test_lest_cpp03.cpp )
 add_executable( test_lest_basic     test_lest_basic.cpp )
 add_executable( test_lest_decompose test_lest_decompose.cpp )
 
+include_directories( "../include/lest" )
+
 if( ${CMAKE_GENERATOR} MATCHES "Visual" )
     add_compile_options( -W3 -EHsc )
 else()

--- a/test/test_lest.cpp
+++ b/test/test_lest.cpp
@@ -83,9 +83,9 @@ const lest::test specification[] =
         report( os, msg, name );
 
 #ifndef __GNUG__
-        EXPECT( os.str() == "---------------------------------------------------\ntest-name\n---------------------------------------------------\nfilename.cpp(765): failed: expression for decomposition\n" );
+        EXPECT( os.str() == "---------------------------------------------------\ntest-name\nfilename.cpp(765): failed: expression for decomposition\n" );
 #else
-        EXPECT( os.str() == "---------------------------------------------------\ntest-name\n---------------------------------------------------\nfilename.cpp:765: failed: expression for decomposition\n" );
+        EXPECT( os.str() == "---------------------------------------------------\ntest-name\nfilename.cpp:765: failed: expression for decomposition\n" );
 #endif
     },
 
@@ -98,9 +98,9 @@ const lest::test specification[] =
         report( os, msg, name );
 
 #ifndef __GNUG__
-        EXPECT( os.str() == "---------------------------------------------------\ntest-name\n---------------------------------------------------\nfilename.cpp(765): failed: didn't get exception: expression\n" );
+        EXPECT( os.str() == "---------------------------------------------------\ntest-name\nfilename.cpp(765): failed: didn't get exception: expression\n" );
 #else
-        EXPECT( os.str() == "---------------------------------------------------\ntest-name\n---------------------------------------------------\nfilename.cpp:765: failed: didn't get exception: expression\n" );
+        EXPECT( os.str() == "---------------------------------------------------\ntest-name\nfilename.cpp:765: failed: didn't get exception: expression\n" );
 #endif
     },
 
@@ -113,9 +113,9 @@ const lest::test specification[] =
         report( os, msg, name );
 
 #ifndef __GNUG__
-        EXPECT( os.str() == "---------------------------------------------------\ntest-name\n---------------------------------------------------\nfilename.cpp(765): failed: got unexpected exception exception-type: expression\n" ); 
+        EXPECT( os.str() == "---------------------------------------------------\ntest-name\nfilename.cpp(765): failed: got unexpected exception exception-type: expression\n" ); 
 #else
-        EXPECT( os.str() == "---------------------------------------------------\ntest-name\n---------------------------------------------------\nfilename.cpp:765: failed: got unexpected exception exception-type: expression\n" );
+        EXPECT( os.str() == "---------------------------------------------------\ntest-name\nfilename.cpp:765: failed: got unexpected exception exception-type: expression\n" );
 #endif
     },
 
@@ -127,7 +127,7 @@ const lest::test specification[] =
 
         run( fail, os );
 
-        EXPECT( 0 == os.str().find("---------------------------------------------------\nF\n---------------------------------------------------\n") );
+        EXPECT( 0 == os.str().find("---------------------------------------------------\nF\n") );
     },
 
     CASE( "Nested setup and section descriptive text is reported" )
@@ -138,7 +138,7 @@ const lest::test specification[] =
 
         run( fail, os );
 
-        EXPECT( 0 == os.str().find("---------------------------------------------------\nF\nSetup\nSection\n---------------------------------------------------\n"));
+        EXPECT( 0 == os.str().find("---------------------------------------------------\nF\nSetup\nSection\n"));
     },
 
     CASE( "Expect generates no message exception for a succeeding test" )

--- a/test/test_lest.cpp
+++ b/test/test_lest.cpp
@@ -83,9 +83,9 @@ const lest::test specification[] =
         report( os, msg, name );
 
 #ifndef __GNUG__
-        EXPECT( os.str() == "filename.cpp(765): failed: test-name: expression for decomposition\n" );
+        EXPECT( os.str() == "---------------------------------------------------\ntest-name\n---------------------------------------------------\nfilename.cpp(765): failed: expression for decomposition\n" );
 #else
-        EXPECT( os.str() == "filename.cpp:765: failed: test-name: expression for decomposition\n" );
+        EXPECT( os.str() == "---------------------------------------------------\ntest-name\n---------------------------------------------------\nfilename.cpp:765: failed: expression for decomposition\n" );
 #endif
     },
 
@@ -98,9 +98,9 @@ const lest::test specification[] =
         report( os, msg, name );
 
 #ifndef __GNUG__
-        EXPECT( os.str() == "filename.cpp(765): failed: didn't get exception: test-name: expression\n" );
+        EXPECT( os.str() == "---------------------------------------------------\ntest-name\n---------------------------------------------------\nfilename.cpp(765): failed: didn't get exception: expression\n" );
 #else
-        EXPECT( os.str() == "filename.cpp:765: failed: didn't get exception: test-name: expression\n" );
+        EXPECT( os.str() == "---------------------------------------------------\ntest-name\n---------------------------------------------------\nfilename.cpp:765: failed: didn't get exception: expression\n" );
 #endif
     },
 
@@ -113,10 +113,32 @@ const lest::test specification[] =
         report( os, msg, name );
 
 #ifndef __GNUG__
-        EXPECT( os.str() == "filename.cpp(765): failed: got unexpected exception exception-type: test-name: expression\n" );
+        EXPECT( os.str() == "---------------------------------------------------\ntest-name\n---------------------------------------------------\nfilename.cpp(765): failed: got unexpected exception exception-type: expression\n" ); 
 #else
-        EXPECT( os.str() == "filename.cpp:765: failed: got unexpected exception exception-type: test-name: expression\n" );
+        EXPECT( os.str() == "---------------------------------------------------\ntest-name\n---------------------------------------------------\nfilename.cpp:765: failed: got unexpected exception exception-type: expression\n" );
 #endif
+    },
+
+    CASE( "CASE-level context is reported" )
+    {
+        std::ostringstream os;
+
+        test fail[] = {{ CASE("F") { EXPECT( false ); } }};
+
+        run( fail, os );
+
+        EXPECT( 0 == os.str().find("---------------------------------------------------\nF\n---------------------------------------------------\n") );
+    },
+
+    CASE( "Nested setup and section descriptive text is reported" )
+    {
+        std::ostringstream os;
+
+        test fail[] = {{ CASE("F") { SETUP("Setup") { SECTION("Section") { EXPECT( false ); }}} }};
+
+        run( fail, os );
+
+        EXPECT( 0 == os.str().find("---------------------------------------------------\nF\nSetup\nSection\n---------------------------------------------------\n"));
     },
 
     CASE( "Expect generates no message exception for a succeeding test" )


### PR DESCRIPTION
- CASE, SETUP, and SECTION now store a context that is reported when an unhandled exception is propogated.
- Added delimiters to CASE/SETUP/SECTION text to separate it from the failure text
- Made BDD text line up since each CASE/SETUP/SECTION description is on a separate line
- Modified tests so the above changes didn't break them
- Added test for the context reporting
- Changed the tests cmakelists.txt to include the lest header directory

This is the beginning of the conversation for including the intermediate text; lest_basic, 03, etc., and their tests have not been modified.
