### PR TITLE
Buck build support

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -21,3 +21,10 @@
 
 # Compiled help files
 *.chm
+
+# Buck / Buckaroo
+/buck-out/
+/.buckd/
+/buckaroo/
+.buckconfig.local
+BUCKAROO_DEPS

--- a/BUCK
+++ b/BUCK
@@ -1,0 +1,11 @@
+prebuilt_cxx_library(
+  name = 'lest',
+  header_only = True,
+  header_namespace = '',
+  exported_headers = subdir_glob([
+    ('include/lest', '**/*.hpp'),
+  ]),
+  visibility = [
+    'PUBLIC',
+  ],
+)

--- a/example/BUCK
+++ b/example/BUCK
@@ -1,0 +1,24 @@
+from os.path import basename
+from os.path import splitext
+
+examples = glob([
+  '*.cpp',
+])
+
+for x in examples:
+  cxx_binary(
+    name = splitext(basename(x))[0],
+    srcs = [
+      x,
+    ],
+    compiler_flags = [
+      '-std=c++11',
+      '-Wall',
+      '-Wextra',
+      '-Wno-missing-braces',
+      '-Dlest_FEATURE_AUTO_REGISTER=1',
+    ],
+    deps = [
+      '//:lest',
+    ],
+  )

--- a/test/BUCK
+++ b/test/BUCK
@@ -1,0 +1,51 @@
+cxx_binary(
+  name = 'test_lest_basic',
+  srcs = [
+    'test_lest_basic.cpp',
+  ],
+  compiler_flags = [
+    '-std=c++11',
+  ],
+  deps = [
+    '//:lest',
+  ],
+)
+
+cxx_binary(
+  name = 'test_lest_cpp03',
+  srcs = [
+    'test_lest_cpp03.cpp',
+  ],
+  compiler_flags = [
+    '-std=c++11',
+  ],
+  deps = [
+    '//:lest',
+  ],
+)
+
+cxx_binary(
+  name = 'test_lest_decompose',
+  srcs = [
+    'test_lest_decompose.cpp',
+  ],
+  compiler_flags = [
+    '-std=c++11',
+  ],
+  deps = [
+    '//:lest',
+  ],
+)
+
+cxx_binary(
+  name = 'test_lest',
+  srcs = [
+    'test_lest.cpp',
+  ],
+  compiler_flags = [
+    '-std=c++11',
+  ],
+  deps = [
+    '//:lest',
+  ],
+)


### PR DESCRIPTION
This PR adds support for builds using [Buck](https://buckbuild.com/).

To run the example:

```
buck run example/:01-basic
buck run example/:02-basic
buck run example/:03-decompose
# etc... 
```

To run the tests:

```
buck run test:test_lest_basic
buck run test:test_lest_cpp03
buck run test:test_lest_decompose
buck run test:test_lest
```

The existing CMake build is unchanged; the two can coexist peacefully 😊