### PR TITLE
Getting rid of `unused parameter ‘lest_env’ [-Werror=unused-parameter]`

### DIFF
--- a/include/lest/lest_cpp03.hpp
+++ b/include/lest/lest_cpp03.hpp
@@ -151,7 +151,7 @@
 #elif defined __GNUC__
 #define lest_MAYBE_UNUSED(ARG) ARG __attribute((unused))
 #else
-#define lest_MAYBE_UNUSED(ARG)
+#define lest_MAYBE_UNUSED(ARG) ARG
 #endif
 
 // Presence of language and library features:

--- a/include/lest/lest_cpp03.hpp
+++ b/include/lest/lest_cpp03.hpp
@@ -139,6 +139,21 @@
 #define lest_CPP17_OR_GREATER  (__cplusplus >= 201703L || lest_MSVC_LANG >= 201703L )
 #define lest_CPP20_OR_GREATER  (__cplusplus >= 202000L || lest_MSVC_LANG >= 202000L )
 
+
+#ifndef __has_cpp_attribute
+#define __has_cpp_attribute(name) 0
+#endif
+
+// Check, if unsued attributes are supported, do nothing, if they are not supported:
+
+#if __has_cpp_attribute(maybe_unused) && lest_CPP17_OR_GREATER
+#define lest_MAYBE_UNUSED(ARG) [[maybe_unused]] ARG
+#elif defined __GNUC__
+#define lest_MAYBE_UNUSED(ARG) ARG __attribute((unused))
+#else
+#define lest_MAYBE_UNUSED(ARG)
+#endif
+
 // Presence of language and library features:
 
 #define lest_HAVE(FEATURE) ( lest_HAVE_##FEATURE )
@@ -251,7 +266,7 @@ namespace lest
 #define lest_CASE( specification, proposition ) \
     static void lest_FUNCTION( lest::env & ); \
     namespace { lest::add_test lest_REGISTRAR( specification, lest::test( proposition, lest_FUNCTION ) ); } \
-    static void lest_FUNCTION( lest::env & lest_env )
+    static void lest_FUNCTION( lest_MAYBE_UNUSED( lest::env & lest_env ) )
 
 #define lest_ADD_TEST( specification, test ) \
     specification.push_back( test )


### PR DESCRIPTION
In the test-file `lest_cpp03.hpp`, the parameter `lest_env` may be not used in the expansion of the macro `lest_CASE`.

The full warning:
```
In file included from build/optional-lite-src/test/optional-main.t.h:18,
                 from build/optional-lite-src/test/optional-main.t.cpp:8:
build/optional-lite-src/test/optional-main.t.cpp: In function ‘void __lest_function__26(lest::env&)’:
build/optional-lite-src/test/lest_cpp03.hpp:266:43: error: unused parameter ‘lest_env’ [-Werror=unused-parameter]
     static void lest_FUNCTION(lest::env & lest_env)
                               ~~~~~~~~~~~~^~~~~~~~
build/optional-lite-src/test/optional-main.t.h:22:22: note: in expansion of macro ‘lest_CASE’
 #define CASE( name ) lest_CASE( specification(), name )
                      ^~~~~~~~~
build/optional-lite-src/test/optional-main.t.cpp:26:1: note: in expansion of macro ‘CASE’
 CASE( "__cplusplus" "[.stdc++]" )
```