### PR TITLE
add workflow for GitHub Actions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,60 @@
+name: CI
+
+on: [ push, pull_request ]
+
+jobs:
+  gcc:
+    strategy:
+      matrix:
+        version: [8, 9, 10, 11]
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      - name: Install GCC ${{ matrix.version }}
+        run: sudo apt-get install -y gcc-${{ matrix.version }} g++-${{ matrix.version }}
+      - name: Configure, build and run tests
+        env:
+          CXX: g++-${{ matrix.version }}
+          CC: gcc-${{ matrix.version }}
+          JOBS: 4
+        run: |
+          mkdir build && cd build
+          cmake -G "Unix Makefiles" ..
+          cmake --build . -- -j${JOBS}
+          ctest --output-on-failure -j${JOBS} -L unittest
+
+  clang:
+    strategy:
+      matrix:
+        version: [8, 9, 10, 11, 12]
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      - name: Install Clang ${{ matrix.version }}
+        run: sudo apt-get install -y clang-${{ matrix.version }}
+      - name: Configure, build and run tests
+        env:
+          CXX: clang++-${{ matrix.version }}
+          CC: clang-${{ matrix.version }}
+          JOBS: 4
+        run: |
+          mkdir build && cd build
+          cmake -G "Unix Makefiles" ..
+          cmake --build . -- -j${JOBS}
+          ctest --output-on-failure -j${JOBS} -L unittest
+
+  msvc:
+    strategy:
+      matrix:
+        os: [windows-2019, windows-2022]
+        configuration: [Debug, Release]
+    runs-on: ${{ matrix.os }}
+    steps:
+      - uses: actions/checkout@v3
+      - name: Configure tests
+        run: cmake -S . -B build
+      - name: Build tests
+        run: cmake --build build --config ${{ matrix.configuration }} -j 4
+      - name: Run tests
+        working-directory: build
+        run: ctest -C ${{ matrix.configuration }} -L unittest -V


### PR DESCRIPTION
I noticed that there is a configuration file for Travis CI (https://github.com/martinmoene/lest/blob/14fa8ee66fe8d2df783c587bcded761291a9b3bb/.travis.yml), but no tests ran on Travis CI for the recent commit 14fa8ee66fe8d2df783c587bcded761291a9b3bb. So only the AppVayor tests with Visual Studio ran. That's why I decided to add GitHub Actions workflows instead.

The Travis CI configuration tests some older compilers like GCC 4.8 to GCC 7 and Clang 3.5 to Clang 6, but I don't think those are available on GitHub Actions. Therefore, the workflow uses some newer compilers. Feel free to adjust this to your needs, if you want to test on other compiler versions, too.


Looks like this when it runs: https://github.com/striezel-stash/lest/actions/runs/2502630546