### PR TITLE
Include `windows.h` (lowercase) to fix cross-compiled MinGW builds

### DIFF
--- a/include/lest/lest_cpp03.hpp
+++ b/include/lest/lest_cpp03.hpp
@@ -66,7 +66,7 @@
 #if lest_FEATURE_TIME
 # if lest_PLATFORM_IS_WINDOWS
 #  include <iomanip>
-#  include <Windows.h>
+#  include <windows.h>
 # else
 #  include <iomanip>
 #  include <sys/time.h>


### PR DESCRIPTION
When cross-compiling from a host that treats file paths as case-sensitive (e.g. Linux) to target Windows using MinGW, the build fails when looking for `Windows.h`.

The solution is to #include this header as `windows.h` (lowercase).