### PR TITLE
Fix some text-incoding inconsistencies

### DIFF
--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -1,4 +1,4 @@
-Changes for lest � lest errors escape testing
+Changes for lest – lest errors escape testing
 
 version 1.35.2 2023-12-28
 
@@ -48,7 +48,7 @@ This bug-fix release fixes reporting of sections, issue #65. Thanks to @onthetop
 
 version 1.33.2 2018-08-28
 
-This bug-fix release suppresses the warning message unused parameter �lest_env� [-Werror=unused-parameter] with lest_cpp03.hpp. Further the style of #if defined has been changed to use parentheses. For the rest, lest.hpp is unchanged.
+This bug-fix release suppresses the warning message unused parameter ‘lest_env’ [-Werror=unused-parameter] with lest_cpp03.hpp. Further the style of #if defined has been changed to use parentheses. For the rest, lest.hpp is unchanged.
 
 version 1.33.1 2018-04-30
 

--- a/example/16-trompeloeil-runtime.cpp
+++ b/example/16-trompeloeil-runtime.cpp
@@ -1,7 +1,7 @@
 // C++14 - use lest with trompeloeil mocking framework (runtime adaptation).
 
 // Trompeloeil, thread-safe single-file header-only C++14 mocking framework,
-// by Björn Fahller (@rollbear), https://github.com/rollbear/trompeloeil
+// by BjÃ¶rn Fahller (@rollbear), https://github.com/rollbear/trompeloeil
 
 #include "lest/lest.hpp"
 #include "trompeloeil.hpp"


### PR DESCRIPTION
This is a very minor thing, but I came across it while investigating packaging `lest` for Fedora: `example/16-trompeloeil-runtime.cpp` is the only non-ASCII source file (because of the `ö` in Björn Fahller’s name), and its encoding is ISO-8869-1. I think that in 2025, UTF-8 would make more sense.

Furthermore, `CHANGES.txt` is valid UTF-8, but some characters were munged during transcoding at some point, leading to the replacement character U+FFFD (UTF-8 byte sequence EF BF BD) appearing at several points. I reconstructed the original intended characters.