### PR TITLE
Fix some of the portability issues in lest_expect_abort

### DIFF
--- a/contrib/lest_expect_abort/Readme.md
+++ b/contrib/lest_expect_abort/Readme.md
@@ -15,7 +15,7 @@ Please note the following:
 
 Dependencies
 ------------
-*lest_expect_abort* requires headers `io.h` and `fcntl.h` for suppression of messages from `assert`.
+*lest_expect_abort* requires header `fcntl.h` and `io.h` (Windows) or `unistd.h` (otherwise) for suppression of messages from `assert`.
 
 
 Assertion macros

--- a/contrib/lest_expect_abort/lest_expect_abort.hpp
+++ b/contrib/lest_expect_abort/lest_expect_abort.hpp
@@ -9,8 +9,14 @@
 #include "lest/lest.hpp"
 
 #include <csetjmp>
+#include <cstdio>
+#include <cstdlib>
 
+#if _WIN32
 #include <io.h>
+#else
+#include <unistd.h>
+#endif
 #include <fcntl.h>
 
 #if ! defined( lest_NO_SHORT_MACRO_NAMES )

--- a/contrib/lest_expect_abort/lest_expect_abort_cpp03.hpp
+++ b/contrib/lest_expect_abort/lest_expect_abort_cpp03.hpp
@@ -9,8 +9,14 @@
 #include "lest/lest_cpp03.hpp"
 
 #include <csetjmp>
+#include <cstdio>
+#include <cstdlib>
 
+#if _WIN32
 #include <io.h>
+#else
+#include <unistd.h>
+#endif
 #include <fcntl.h>
 
 #if ! defined( lest_NO_SHORT_MACRO_NAMES )


### PR DESCRIPTION
Unconditionally include `cstdio` for `fflush` and friends, and `cstdlib` for `abort`. When `_WIN32` is not defined, include `unistd.h` instead of `io.h` for `dup` and `dup2`.

This fixes some of the portability issues in `lest_expect_abort` contrib library, and I guess we can consider that it fixes #39, but it does not entirely fix building `lest_expect_abort`:

```
In file included from /home/ben/src/forks/lest/contrib/lest_expect_abort/test/lest_expect_abort.t.cpp:9:
/home/ben/src/forks/lest/contrib/../contrib/lest_expect_abort/lest_expect_abort_cpp03.hpp:85:62: error: expected initializer before ‘abort’
   85 | #  define lest_ABORT_SIGNATURE()  lest_NORETURN void __cdecl abort()
      |                                                              ^~~~~
/home/ben/src/forks/lest/contrib/../contrib/lest_expect_abort/lest_expect_abort_cpp03.hpp:167:1: note: in expansion of macro ‘lest_ABORT_SIGNATURE’
  167 | lest_ABORT_SIGNATURE()
      | ^~~~~~~~~~~~~~~~~~~~
gmake[2]: *** [contrib/lest_expect_abort/test/CMakeFiles/contrib-abort-lest_expect_abort.t_cpp03.dir/build.make:79: contrib/lest_expect_abort/test/CMakeFiles/contrib-abort-lest_expect_abort.t_cpp03.dir/lest_expect_abort.t.cpp.o] Error 1
gmake[2]: Leaving directory '/home/ben/src/forks/lest/build'
gmake[1]: *** [CMakeFiles/Makefile2:601: contrib/lest_expect_abort/test/CMakeFiles/contrib-abort-lest_expect_abort.t_cpp03.dir/all] Error 2
gmake[1]: *** Waiting for unfinished jobs....
In file included from /home/ben/src/forks/lest/contrib/lest_expect_abort/example/00_basic.cpp:2:
/home/ben/src/forks/lest/contrib/../contrib/lest_expect_abort/lest_expect_abort.hpp:87:62: error: expected initializer before ‘abort’
   87 | #  define lest_ABORT_SIGNATURE()  lest_NORETURN void __cdecl abort()
      |                                                              ^~~~~
/home/ben/src/forks/lest/contrib/../contrib/lest_expect_abort/lest_expect_abort.hpp:160:1: note: in expansion of macro ‘lest_ABORT_SIGNATURE’
  160 | lest_ABORT_SIGNATURE()
      | ^~~~~~~~~~~~~~~~~~~~
In file included from /home/ben/src/forks/lest/contrib/lest_expect_abort/example/01_specification.cpp:7:
/home/ben/src/forks/lest/contrib/../contrib/lest_expect_abort/lest_expect_abort.hpp:87:62: error: expected initializer before ‘abort’
   87 | #  define lest_ABORT_SIGNATURE()  lest_NORETURN void __cdecl abort()
      |                                                              ^~~~~
/home/ben/src/forks/lest/contrib/../contrib/lest_expect_abort/lest_expect_abort.hpp:160:1: note: in expansion of macro ‘lest_ABORT_SIGNATURE’
  160 | lest_ABORT_SIGNATURE()
      | ^~~~~~~~~~~~~~~~~~~~
In file included from /home/ben/src/forks/lest/contrib/lest_expect_abort/test/lest_expect_abort.t.cpp:7:
/home/ben/src/forks/lest/contrib/../contrib/lest_expect_abort/lest_expect_abort.hpp:87:62: error: expected initializer before ‘abort’
   87 | #  define lest_ABORT_SIGNATURE()  lest_NORETURN void __cdecl abort()
      |                                                              ^~~~~
/home/ben/src/forks/lest/contrib/../contrib/lest_expect_abort/lest_expect_abort.hpp:160:1: note: in expansion of macro ‘lest_ABORT_SIGNATURE’
  160 | lest_ABORT_SIGNATURE()
      | ^~~~~~~~~~~~~~~~~~~~
```

Here it looks like the design of `lest_expect_abort` expects to have the exact signature of `abort`, and it‘s attempting to satisfy that requirement with some preprocessor conditionals that are both dated and Windows-specific:

https://github.com/martinmoene/lest/blob/778597f6dcf273a4b4d87c2c1062d0b584fa2aa8/contrib/lest_expect_abort/lest_expect_abort.hpp#L75-L87

Well, that’s probably why this is in contrib and not in the main library. Still, this PR should be a step in the right direction for anyone who might be trying to make it work. This is probably the last PR I’ll submit related to the contrib libraries.